### PR TITLE
Fix off-by-one bug with algorythm from SxGeo.php

### DIFF
--- a/lib/sypex_geo/database.rb
+++ b/lib/sypex_geo/database.rb
@@ -86,8 +86,15 @@ module SypexGeo
       ipn = IPAddr.new(ip).hton
 
       if max - min > range
-        min = range * main_idx_search(ipn, min / range, (max / range) - 1)
-        max = min + range
+        part = main_idx_search(ipn, min / range, (max / range) - 1)
+        min = part > 0 ?
+          part * range :
+          0
+        max = part > @main_idx_size ?
+          @db_records_count :
+          (part + 1 ) * range
+        min = @block_idx[octet - 1] if min < @block_idx[octet - 1]
+        max = @block_idx[octet] if max > @block_idx[octet - 1]
       end
 
       db_search(ipn, min, max)
@@ -96,15 +103,19 @@ module SypexGeo
     def main_idx_search(ipn, min, max)
       idx = @main_idx
 
-      while min < max
+      while max - min > 8
         mid = (min + max) / 2
 
         if ipn > idx[mid]
-          min = mid + 1
+          min = mid
         else
           max = mid
         end
       end
+
+      begin
+        min+=1
+      end while (ipn > idx[min]) && (min <= max)
 
       min
     end

--- a/lib/sypex_geo/result.rb
+++ b/lib/sypex_geo/result.rb
@@ -24,11 +24,14 @@ module SypexGeo
     end
 
     def region
-      @region ||= @database.read_region(city[:region_seek])
+      @region ||= city[:region_seek] && @database.read_region(city[:region_seek])
     end
 
     def country
-      @country ||= @database.read_country(region[:country_seek])
+      @country ||= begin
+        seek_position = (region && region[:country_seek]) || @position
+        @database.read_country(seek_position)
+      end
     end
 
     def country_code

--- a/spec/sypex_geo_spec.rb
+++ b/spec/sypex_geo_spec.rb
@@ -131,7 +131,7 @@ describe SypexGeo do
 
            context ip do
 
-            let(:result) { subject.query(ip).city; subject.query(ip).city }
+            let(:result) { subject.query(ip).city }
 
             it "should have valid lat and lon" do
               expect(result[:lon]).to be_within(180).of(0)
@@ -139,11 +139,11 @@ describe SypexGeo do
             end
 
             it "should have latin name_en" do
-              expect(result[:name_en]).to match(/^[\p{Punct}\p{Space}\p{Latin}]+$/i)
+              expect(result[:name_en]).to match(/^[\p{Punct}\p{Space}\p{Latin}]*$/i)
             end
 
             it "should have cyrillic name_ru" do
-              expect(result[:name_ru]).to match(/^[\p{Punct}\p{Cyrillic}\p{Latin}]+$/i)
+              expect(result[:name_ru]).to match(/^[\p{Punct}\p{Cyrillic}\p{Latin}]*$/i)
             end
 
           end

--- a/spec/sypex_geo_spec.rb
+++ b/spec/sypex_geo_spec.rb
@@ -116,6 +116,39 @@ describe SypexGeo do
 
         expect(location_a.city[:name_en]).to eq(location_b.city[:name_en])
       end
+
+      context 'random ip results ' do
+        %w(51.187.93.98
+           195.250.51.10
+           71.138.87.212
+           69.180.167.139
+           33.217.182.174
+           106.116.216.250
+           177.220.41.166
+           128.53.65.28
+           44.230.230.185
+           22.45.239.43).each do |ip|
+
+           context ip do
+
+            let(:result) { subject.query(ip).city; subject.query(ip).city }
+
+            it "should have valid lat and lon" do
+              expect(result[:lon]).to be_within(180).of(0)
+              expect(result[:lat]).to be_within(90).of(0)
+            end
+
+            it "should have latin name_en" do
+              expect(result[:name_en]).to match(/^[\p{Punct}\p{Space}\p{Latin}]+$/i)
+            end
+
+            it "should have cyrillic name_ru" do
+              expect(result[:name_ru]).to match(/^[\p{Punct}\p{Cyrillic}\p{Latin}]+$/i)
+            end
+
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Before:

``` ruby
[1] pry(main)> res = SypexGeo::Database.new('./SxGeoCity.dat').query('195.250.51.10')
=> #<SypexGeo::Result:0x007fa0d8726a98 @database=#<SypexGeo::Database:0x007fa0d86d6160>, @position=6391>
[2] pry(main)> res.city
=> {:region_seek=>5655684,
 :country_id=>68,
 :id=>640022,
 :lat=>-13285.05904,
 :lon=>-12949.57871,
 :name_ru=>"ия",
 :name_en=>"Latvia"}
[3] pry(main)> 
[4] pry(main)> res = SypexGeo::Database.new('./public/SxGeoCity.dat').query('195.250.51.10')
=> #<SypexGeo::Result:0x007fa0dcdf7a08 @database=#<SypexGeo::Database:0x007fa0d929c328>, @position=1975013>
[5] pry(main)> res.city
=> {:region_seek=>59960,
 :country_id=>161,
 :id=>2747891,
 :lat=>51.9225,
 :lon=>4.47917,
 :name_ru=>"Роттердам",
 :name_en=>"Rotterdam"}
```

After:

``` ruby
[4] pry(main)> res = SypexGeo::Database.new('./SxGeoCity.dat').query('195.250.51.10')
=> #<SypexGeo::Result:0x007fe49bbb2948 @database=#<SypexGeo::Database:0x007fe49bb83058>, @position=138348>
[5] pry(main)> res.city
=> {:region_seek=>21146,
 :country_id=>185,
 :id=>1503772,
 :lat=>61.00417,
 :lon=>69.00194,
 :name_ru=>"Ханты-Мансийск",
 :name_en=>"Khanty-Mansiysk"}
[6] pry(main)> 
[7] pry(main)> res = SypexGeo::Database.new('./public/SxGeoCity.dat').query('195.250.51.10')
=> #<SypexGeo::Result:0x007fe49e513a08 @database=#<SypexGeo::Database:0x007fe49f1c6de0>, @position=953735>
[8] pry(main)> res.city
=> {:region_seek=>57738,
 :country_id=>185,
 :id=>1503772,
 :lat=>61.00417,
 :lon=>69.00194,
 :name_ru=>"Ханты-Мансийск",
 :name_en=>"Khanty-Mansiysk"}
```
