### PR TITLE
Fix spec case when no any info about ip address

### DIFF
--- a/lib/sypex_geo/result.rb
+++ b/lib/sypex_geo/result.rb
@@ -37,7 +37,13 @@ module SypexGeo
 
     def country_code
       @country_code ||= begin
-        COUNTRY_CODES[(@database.country? ? @position : (city && city[:country_id])) - 1]
+        country_index = if @database.country?
+                          @position
+                        elsif city
+                          city[:country_id]
+                        end
+
+        COUNTRY_CODES[country_index - 1] if country_index
       end
     end
   end

--- a/spec/sypex_geo_spec.rb
+++ b/spec/sypex_geo_spec.rb
@@ -151,7 +151,7 @@ describe SypexGeo do
       end
 
       context 'return nil if ip not present' do
-        let(:ip) { '78.172.97.26' }
+        let(:ip) { '212.5.219.198' }
 
         it 'should return nil for city' do
           expect(subject.query(ip).city).to eq(nil)


### PR DESCRIPTION
1) Sypex Geo already has info about `78.172.97.26`, so I changed IP address.
2) Fixed `Result#country_code` to fix error:
```
NoMethodError:
  undefined method `-' for nil:NilClass
  # ./lib/sypex_geo/result.rb:40:in `country_code'
```
https://travis-ci.org/kolesnikovde/sypex_geo/jobs/303509712#L665